### PR TITLE
chore(ci): bump deprecated Node 16/20 actions to Node 24 (PLA-20 follow-up)

### DIFF
--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '${{ inputs.go_version }}'
           check-latest: true
@@ -48,7 +48,7 @@ jobs:
         working-directory: ${{ inputs.module }}
         run: rm coverage.tmp.out
       - name: Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: false
           flags: ${{ inputs.module }}
@@ -59,11 +59,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go_version }}
       - name: Install lint

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,11 +23,11 @@ jobs:
         - "fxtestcontainer"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.22"
           check-latest: true
@@ -44,7 +44,7 @@ jobs:
         working-directory: ${{ matrix.module }}
         run: rm coverage.tmp.out
       - name: Codecov for module ${{ matrix.module }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: false
           flags: ${{ matrix.module }}


### PR DESCRIPTION
## Context
Follow-up to **PLA-20** (Node 20 -> 24 GitHub Actions). A full org `origin/HEAD` scan found this repo’s **workflow files** still referenced Node 16/20 actions. This PR bumps them to their latest Node 24-compatible major.
## Bumps
- `actions/checkout@v3` -> `actions/checkout@v6`
- `actions/checkout@v4` -> `actions/checkout@v6`
- `actions/setup-go@v4` -> `actions/setup-go@v6`
- `actions/setup-go@v5` -> `actions/setup-go@v6`
- `codecov/codecov-action@v3` -> `codecov/codecov-action@v7`
## Not included
Actions with no clean Node 24 path (archived, still-node20, or breaking majors like `golangci-lint-action`, `release-please-action`, `slack-github-action`) were intentionally left out and are tracked in **PLA-133**.
